### PR TITLE
Verschiedene Korrekturen

### DIFF
--- a/INF-110-DS/DS.tex
+++ b/INF-110-DS/DS.tex
@@ -73,7 +73,7 @@
 
 
 \setlength{\parindent}{0pt}
-\setlength{\parskip}{3pt} 
+\setlength{\parskip}{3pt}
 
 
 \title{Diskrete Strukturen}
@@ -164,7 +164,7 @@ Mengen können auch andere Mengen als Elemente enthalten:\\
 \subsubsection{Die Kardinalität einer Menge}
 
 \de{Die \red{Kardinalität} $|M|$, auch Mächtigkeit, einer Menge M beschreibt die Anzahl der Elemente in M.}
-    
+
 \ex
 \begin{itemize}
     \item $|\{0, 1, 2\}| = |\{0, 0, 0, 1, 2, 2\}| = 3$
@@ -204,7 +204,7 @@ Mengen können auch andere Mengen als Elemente enthalten:\\
                  Schnitt: A \cap B  & = & \{ x \vst x \in A \land x \in B \} \\
                                     & = & \{ x \in A  \vst x \in B \}\\
                                     & = & \{x \in B \vst x \in A\}
-            \end{array} 
+            \end{array}
         \) &
         \begin{tikzpicture}
             \draw[thick, black] (0, 0) ellipse (1 and 0.5) node[left] {$A$};
@@ -246,7 +246,7 @@ Mengen können auch andere Mengen als Elemente enthalten:\\
             \begin{array}{lcl}
                  Disjunktion: A \perp B  & \iff & A \cap B = \emptyset \\
                                          & \iff & \forall x \in A \vst x \notin B\\
-            \end{array} 
+            \end{array}
         \) &
         \begin{tikzpicture}
             \draw[thick, black] (0, 0) ellipse (0.8 and 0.5) node {$A$};
@@ -432,7 +432,7 @@ Es existiert (nach der zweiten Definition) also genau eine Zahl $z$ in $\N$, sod
 \subsubsection{Beispiel: Handschlaglemma}
 \lem{
     Auf einer Konferenz ist die Anzahl der Teilnehmenden, die einer ungeraden Teilnehmerzahl die Hand gibt, immer gerade.
-} 
+}
 
 \pr{
     Sei $T = \{t_1, t_2, \dots, t_n\}$ die Menge aller Teilnehmenden der Konferenz, so definieren wir
@@ -562,7 +562,7 @@ Um herauszufinden, wie sich der Binomialkoeffizient $\binom{n}{k}$ berechnen lä
 
     Nach der Definition des Binomialkoeffizienten gilt für die Menge $M$:
     \begin{equation*}
-        |P(M)| = \binom{n + 1}{k} 
+        |P(M)| = \binom{n + 1}{k}
     \end{equation*}
     Damit gilt durch gleichsetzen:
     \begin{equation*}
@@ -616,7 +616,7 @@ Um herauszufinden, wie sich der Binomialkoeffizient $\binom{n}{k}$ berechnen lä
 }
 Es gilt:
 \begin{equation*}
-    b = f(a) \iff (a, b) \in G_f   
+    b = f(a) \iff (a, b) \in G_f
 \end{equation*}
 \gray{Das Paar $(a, b)$ ist genau dann in $G_f$, wenn die Abbildung von $a$ auf $B$ bzw $f(a)$ $b$ ergibt}
 
@@ -645,17 +645,17 @@ Es gilt:
             \begin{tikzpicture}
                 \draw[thick] (0, 0.8) ellipse (0.5 and 1.3);
                 \draw[thick] (2.5, 0.8) ellipse (0.5 and 1.3);
-    
+
                 \node (A1) at (0,1.2) {$a_1$};
                 \node (A2) at (0,0.4) {$a_2$};
-    
+
                 \node (B1) at (2.5,1.6) {\green{$b_1$}};
                 \node (B2) at (2.5,0.8) {\red{$b_2$}};
                 \node (B3) at (2.5,0) {\green{$b_3$}};
-    
+
                 \node (A) at (0,2.5) {$A$};
                 \node (B) at (2.5,2.5) {$B$};
-    
+
                 \draw[thick, ->] (A) -- (B);
                 \draw[green, ->, bend left] (A1) to (B1);
                 \draw[green, ->, bend right] (A2) to (B3);
@@ -674,17 +674,17 @@ Es gilt:
             \begin{tikzpicture}
                 \draw[thick] (0, 0.8) ellipse (0.5 and 1.3);
                 \draw[thick] (2.5, 0.8) ellipse (0.5 and 1.3);
-    
+
                 \node (A1) at (0,1.6) {$a_1$};
                 \node (A2) at (0,0.8) {$a_2$};
                 \node (A3) at (0,0) {$a_3$};
-    
+
                 \node (B1) at (2.5,1.2) {\green{$b_1$}};
                 \node (B2) at (2.5,0.4) {\green{$b_2$}};
-    
+
                 \node (A) at (0,2.5) {$A$};
                 \node (B) at (2.5,2.5) {$B$};
-    
+
                 \draw[thick, ->] (A) -- (B);
                 \draw[green, ->, bend left] (A1) to (B1);
                 \draw[red, ->, bend right] (A2) to (B1);
@@ -704,18 +704,18 @@ Es gilt:
             \begin{tikzpicture}
                 \draw[thick] (0, 0.8) ellipse (0.5 and 1.3);
                 \draw[thick] (2.5, 0.8) ellipse (0.5 and 1.3);
-    
+
                 \node (A1) at (0,1.6) {$a_1$};
                 \node (A2) at (0,0.8) {$a_2$};
                 \node (A3) at (0,0) {$a_3$};
-    
+
                 \node (B1) at (2.5,1.6) {$b_1$};
                 \node (B2) at (2.5,0.8) {$b_2$};
                 \node (B3) at (2.5,0) {$b_3$};
-    
+
                 \node (A) at (0,2.5) {$A$};
                 \node (B) at (2.5,2.5) {$B$};
-    
+
                 \draw[thick, ->] (A) -- (B);
                 \draw[->] (A1) -- (B1);
                 \draw[->] (A2) -- (B2);
@@ -826,7 +826,7 @@ Bei der Mehrfachanwendung einer Abbildung gilt:\\
 $f: \N \to \N, \; x \mapsto \begin{cases}
     x & \text{falls } x = 0\\
     x - 1 & \text{falls } x > 0\\
-\end{cases}$ 
+\end{cases}$
 ist surjektiv, nicht injektiv, da $f(0) = f(1)$
 }
 
@@ -842,9 +842,9 @@ ist surjektiv, nicht injektiv, da $f(0) = f(1)$
 
 \ex \begin{itemize}
     \item $|\{1, 2, 3\}| = |\{*, \star, x\}|$
-    
+
     \begin{minipage}{9.1cm}
-        \item $|\N| = |\Z|$, denn $f: \N \to \Z, \; x \mapsto 
+        \item $|\N| = |\Z|$, denn $f: \N \to \Z, \; x \mapsto
         \begin{cases}
             \frac{x}{2} & \text{, falls } x \text{ gerade}\\
             -\frac{x + 1}{2} & \text{, falls } x \text{ ungerade}
@@ -884,8 +884,8 @@ ist surjektiv, nicht injektiv, da $f(0) = f(1)$
     Wir zeigen zuerst "$\leq$". Sei $f: A \to P(A), \; a \mapsto \{a\}$, dann ist $f$ injektiv, also $|A| \leq |P(A)|$\\
     \gray{Da $P(A)$ für jedes Element $a \in A$ eine Menge $\{a\} \in P(A)$ enthält, kann hier das Element $a \in A$ auf $\{a\} \in P(A)$ abgebildet werden.}
 
-    Jetzt zeigen wir "$\neq$": Wir müssen zeigen, dass eine injektive Abbildung $f: A \to P(A)$ niemals surjektiv ist. 
-    
+    Jetzt zeigen wir "$\neq$": Wir müssen zeigen, dass eine injektive Abbildung $f: A \to P(A)$ niemals surjektiv ist.
+
     Sei $M := \{a \in A \vst a \notin P(A)\} \in P(a)$. Wir zeigen: $M \notin f[A]$
 
     Widerspruchsannahme: Sei $a \in A$ mit $f(a) = M$.
@@ -923,21 +923,21 @@ Es gibt zwei gebräuchliche Schreibweisen für Permutationen:
             2 & 3 & 1 & 4
         \end{pmatrix}$
     \end{tabular}
-    \item Zyklen-Schreibweise: $\pi = (1 \; 2 \; 3)(4) = (1 \; 2 \; 3)$, wobei Zyklen disjunkt sind 
+    \item Zyklen-Schreibweise: $\pi = (1 \; 2 \; 3)(4) = (1 \; 2 \; 3)$, wobei Zyklen disjunkt sind
 \end{itemize}
 \begin{center}
     \begin{tikzpicture}
         \node[circle, draw] (1) at (0,1) {$1$};
         \node[circle, draw] (2) at (1.6,2.6) {$2$};
         \node[circle, draw] (3) at (2.3,0.5) {$3$};
-    
+
         \draw[->,] (1) to (2);
         \draw[->,] (2) to (3);
         \draw[->,] (3) to (1);
-    
+
         \node[circle, draw] (4) at (5, 1) {$4$};
         \draw[->, loop above, out=150, in=30, looseness=15] (4) to (4);
-    
+
         \draw[red] (1.3,1.3) circle (1.8);
         \draw[blue] (5,1.5) circle (1.3);
         \node[red] at (1.3, -1) {Zyklus};
@@ -1030,17 +1030,17 @@ Bei der Komposition von Zyklen gibt es mehrere Rechenregeln:
     \begin{equation*}
         \begin{array}{lcl}
             \pi \circ \{x_1, ..., x_k\} \circ \pi^{-1}(\pi(i)) & = & \pi \circ \{x_1, ..., x_k\} \circ (i)\\
-            & = & 
+            & = &
             \begin{cases}
                 \pi(x_{j+1}), \; i \notin \{x_1, ..., x_k\}\\
                 \pi(x_l + 1), \; i = x_l\\
                 \pi(x_1), \; i = x_k
             \end{cases}
         \end{array}
-    \end{equation*}    
+    \end{equation*}
 }
 
-\ex 
+\ex
 \begin{equation*}
     \begin{array}{lcl}
         (1 \; 2) (3 \; 4 \; 5) \circ (2 \; 3) (1 \; 5) & = & (1 \; 2) (3 \; 4 \; 5) \circ (5 \; 1) (2 \; 3)\\
@@ -1269,7 +1269,7 @@ Sei $(a_1, \dots, a_n) \in \{0, 1\}^n$, falls A die Gestalt
 \[
     \begin{array}{lcl}
         \bigvee_{\emptyset} = \perp & A \lor \bigvee_{\emptyset} \iff A
-    \end{array}        
+    \end{array}
 \]
 \gray{Eine Disjunkton ist genau dann wahr, wenn mindestens eine der vereinigten Aussagen wahr ist.}
 \[
@@ -1282,7 +1282,7 @@ Sei $(a_1, \dots, a_n) \in \{0, 1\}^n$, falls A die Gestalt
 \an{
     In der Praxis benutzen wir oft:
     \begin{itemize}
-        \item Ringschluss: 
+        \item Ringschluss:
         \[
             (X_1 \implies X_2) \land (X_2 \implies X_3) \land \dots \land (X_n \implies X_1)
         \]
@@ -1338,11 +1338,11 @@ Ein Ausdruck ist in KNF, falls er die Form
         ((X_1 \land Y_1) \lor (x_2 \land Y_2) \lor \dots \lor (X_n \land Y_n)) \text{ (DNF)}
     \]
     \[
-        \rightsquigarrow ((X_1 \land Y_1) \lor \dots \lor (X_n \land Y_n) \lor X_n) \land ((X_1 \land Y_1) \lor \dots \lor (X_n \land Y_n) \lor Y_n)    
+        \rightsquigarrow ((X_1 \land Y_1) \lor \dots \lor (X_n \land Y_n) \lor X_n) \land ((X_1 \land Y_1) \lor \dots \lor (X_n \land Y_n) \lor Y_n)
     \]
     \[\vdots\]
     \(2^n\) Konjunkte, d.h. \(2^n\) Klauseln.
-    
+
     Es gilt: Wenn es für das Erfüllbarkeitsproblem in KNF einen\\
     polynomiellen Algorithmus gibt, dann auch für das allgemeine\\
     Erfüllbarkeitsproblem!
@@ -1356,7 +1356,7 @@ Ein Ausdruck ist in KNF, falls er die Form
     Ein Ausdruck heißt \red{Horn}, falls jede Klausel höchstens ein positives Literal hat.\\
     \ex \underbar{X} $\land$ \underbar{U} $\land$ \underbar{$\n{Z}$} $\land$ \underbar{$(\n{X} \lor Y)$} $\land$ \underbar{$(\n{U} \lor \n{Y} \lor Z)$}\\
     Umformuliert: $X \land U \land \n{Z} \land (X \implies Y) \land ((U \land Y) \implies Z)$
-    
+
     \begin{minipage}{2.2cm}
         \phantom{}
     \end{minipage}
@@ -1532,7 +1532,7 @@ $A_n$ ist die Aussage $\sum_{i = 0}^{n}i = \frac{n \cdot (n+1)}{2}$
 \se{
     Seien $A,B$ Mengen mit $|A| = |B| < \infty$ und sei $f: A \to B$ eine Abbildung, dann gilt:
     \[
-        f \text{ ist injektiv} \iff f \text{ ist surjektiv} \iff f \text{ ist bijektiv}   
+        f \text{ ist injektiv} \iff f \text{ ist surjektiv} \iff f \text{ ist bijektiv}
     \]
 }
 \pr{
@@ -1544,7 +1544,7 @@ $A_n$ ist die Aussage $\sum_{i = 0}^{n}i = \frac{n \cdot (n+1)}{2}$
 
     IS: Seien $A,B$ Mengen mit $|A| = |B| = n+1 > 0$ und $f: A \to B$ injektiv.\\
     Sei $a \in A$. Ein solches $a$ existiert, da $A \neq \emptyset$
-    
+
     $f$ injektiv $\implies \forall a' \in A$ mit $a' \neq \emptyset: f(a') \neq f(a)'$,\\
     \gray{Zwei Elemente aus A zeigen nicht auf das gleiche Element in B, da die Abbildung injektiv ist}
 
@@ -1622,7 +1622,7 @@ Falls $a \vst b$, dann $\frac{b}{q} = k$ mit $a \cdot k = b$
 \begin{center}
     \begin{tikzpicture}
         \node (1) at (0,0) {1};
-    
+
         \node (2) at (-1,1) {2};
         \node (3) at (0,1) {3};
         \node (5) at (1,1) {5};
@@ -1637,7 +1637,7 @@ Falls $a \vst b$, dann $\frac{b}{q} = k$ mit $a \cdot k = b$
         \node (30) at (1, 4) {30};
 
         \node (60) at (0, 5) {60};
-    
+
         \draw[->] (2) -- (1) node[midway, left] {$\cdot 2$};
         \draw[->] (3) -- (1) node[midway, left] {$\cdot 3$};
         \draw[->] (5) -- (1) node[midway, right] {$\cdot 5$};
@@ -1667,7 +1667,7 @@ Falls $a \vst b$, dann $\frac{b}{q} = k$ mit $a \cdot k = b$
 \an{
     Sei $\pi(n)$ die Anzahl der Primzahlen $\leq n$. Es gibt eine "asymptotische Abschätzung" für $\pi(n)$, der Primzahlsatz:
     \[
-        \pi(n) \sim \frac{n}{\ln(n)}   
+        \pi(n) \sim \frac{n}{\ln(n)}
     \]
     d.h.
     \[
@@ -1751,7 +1751,7 @@ Primzahlen sind die "Elementarbausteine" der natürlichen Zahlen.
 
     $d \st a$ und $d \st b \implies d \st \underbrace{(a - b \cdot q)}_r$, also $d \leq d'$\\
     \gray{Da $d$ Teiler von $b$ und $r$ und $d'$ der ggT von $b$ und $r$, muss $d \leq d'$}
-    
+
     $d' \st b$ und $d' \st r \implies d' \st \underbrace{(b \cdot q + r)}_a$, also $d' \leq d$\\
     \gray{Wie oben folgt hieraus analog $d' \leq d$}
 
@@ -1781,7 +1781,7 @@ Primzahlen sind die "Elementarbausteine" der natürlichen Zahlen.
 
     \underline{$IS$:} Seien $m,n \in \{0, \dots, k+1\}$\\
     Falls $m = n$: $m = n = ggT(m,n)$ und $m = 1 \cdot m + 0 \cdot n$
-    
+
     Falls $m \neq n$, O.B.d.A. $m < n$\\
     Seien $q,r \in \N$ mit $r < m$ und $n = q \cdot m + r$\\
     Dann: $ggT(m,n) = ggT(r, m) \overset{IV}{=} (\exists a',b' \in \Z:) a' \cdot r + b' \cdot m$
@@ -1872,7 +1872,7 @@ Primfaktorzerlegung von $1$: $\prod_{i = 1}^{\emptyset}p_1^{a_i} = 1$ (leeres Pr
     mit \begin{enumerate}
         \item $x \mod m = k \mod m$ bzw. $x \equiv k \mod m$
         \item $x \mod n = l \mod n$ bzw. $x \equiv l \mod n$
-    \end{enumerate} 
+    \end{enumerate}
 }
 \pr{
     Nach Bezout: $\exists a,b \in \Z: am + bn = 1$
@@ -2022,7 +2022,7 @@ mit $\cdot: \Z_n^2 \to \Z_n: (x,y) \mapsto (x \cdot y) \mod n$
     \item ist assoziativ \checkmark
     \item neutrales Element 1
     \item Inverses Element: $x \cdot x^{-1} \equiv x^{-1} \cdot x \equiv 1 \; (\mod n)$
-\end{itemize} 
+\end{itemize}
 
 $Z_6 = \{0,1,2,3,4,5\}$
 
@@ -2144,13 +2144,13 @@ $|x| > 2$, dann ist Sym$(x)$ \underline{nicht} abelsch:
 $\pi_1 = \begin{pmatrix}
     1 & 2 & 3\\
     2 & 3 & 1
-\end{pmatrix} 
+\end{pmatrix}
 = (1 \; 2 \; 3)$
 
 $\pi_2 = \begin{pmatrix}
     1 & 2 & 3\\
     2 & 1 & 3
-\end{pmatrix} 
+\end{pmatrix}
 = (1 \; 2) \; (3)$
 
 \subsubsection{Erzeuger}
@@ -2233,7 +2233,7 @@ Dann ist $\exp_g: Z_{p-1} \to \Z_p^*: k \mapsto g^k$ ein Isomorphismus.
     Der \red{diskrete Logarithmus} zur Basis $g$ ist definiert als die\\
     Umkehrfunktion von $\exp_g$:
     \[
-        \log_g: \Z_p^* \to \Z_{p-1}: a \mapsto k \text{ mit } g^k \equiv a \; (\mod p)   
+        \log_g: \Z_p^* \to \Z_{p-1}: a \mapsto k \text{ mit } g^k \equiv a \; (\mod p)
     \]
 }
 
@@ -2543,7 +2543,7 @@ Diese Graphen heißen schlicht bzw. einfach und ungerichtet.
     Dann sind $G,H$ isomorph.
 }
 
-\ex Ein Isomorphismus von $C_5$ nach $\n{C_5}$ lautet: 
+\ex Ein Isomorphismus von $C_5$ nach $\n{C_5}$ lautet:
 $$f \in S_n, f = \begin{pmatrix}
     1 & 2 & 3 & 4 & 5\\
     1 & 3 & 5 & 2 & 4
@@ -2835,25 +2835,25 @@ Graph $G_B = (V_B, E_B)$ mit
 \pr{
     Angenommen, \(G_B\) enthält einen Kreis \((a_0, B_0, a_1, B_1, \dots, B_k, a_0)\).  \\
     Es gilt: \(V(B_i) \cap V(B_j) \subseteq \{a_i\}\), d.h., zwei Blöcke teilen\\
-    höchstens einen Knoten, nämlich einen Gelenkpunkt.  
+    höchstens einen Knoten, nämlich einen Gelenkpunkt.
 
     Da \(G_B\) einen Kreis enthält, gibt es einen geschlossenen Pfad im\\
     ursprünglichen Graphen \(G\), der durch die Blöcke \(B_0, B_1, \dots, B_k\) \\läuft.\\
     Konkret gibt es in jedem \(B_i\) einen Weg von \(a_i\) nach \(a_{(i+1) \mod k}\).\\
     Indem diese Wege aneinandergefügt werden, ergibt sich ein Kreis \\
-    in \(G\).  
+    in \(G\).
 
     Das ist ein Widerspruch zur Definition eines Gelenkpunktes:\\
     Gelenkpunkte trennen \(G\), sodass es nach ihrem Entfernen\\
     keine Kreise geben kann, die über mehrere Blöcke hinweg\\
-    verlaufen. Also ist \(G_B\) kreisfrei und damit ein Wald.  
+    verlaufen. Also ist \(G_B\) kreisfrei und damit ein Wald.
 
     Ist \(G\) zusammenhängend, so gibt es zwischen jedem Paar von\\
     Blöcken \(B_i\) und \(B_j\) einen Weg\\
-    in \(G\), der über Gelenkpunkte führt. Da \(G_B\) die Blöcke als Knoten und die Gelenkpunkte als Kanten repräsentiert, ist \(G_B\) ebenfalls zusammenhängend.  
+    in \(G\), der über Gelenkpunkte führt. Da \(G_B\) die Blöcke als Knoten und die Gelenkpunkte als Kanten repräsentiert, ist \(G_B\) ebenfalls zusammenhängend.
 
     Da \(G_B\) ein kreisfreier und zusammenhängender Graph ist, ist \\
-    \(G_B\) ein Baum. 
+    \(G_B\) ein Baum.
 }
 
 \subsection{Ohrendekomposition}
@@ -2888,7 +2888,7 @@ Graph $G_B = (V_B, E_B)$ mit
     \begin{itemize}
         \item[Fall 1] $v \in \{a_0, \dots a_n\}: G-v$ ist $G_n$ und zwei angehängte Pfade, also zusammenhängend
         \item[Fall 2] $v \in V \backslash \{G_n\}: G-v$ ist $G_n-v$ und ein angehängter Weg. $G_n-v$ st nach \underline{IV} zusammenhängend, also ist $G-v$ zusammenhängend.
-    \end{itemize} 
+    \end{itemize}
 
     \underline{Richtung $\implies$}: Sei $G$ ein 2-fach zusammenhängender Graph.\\
     Sei $H$ ein Subgraph von $G$, der eine Ohrendekomposition hat, sodass es keinen Subgraphen von $G$ gibt, der größer als $H$ und auch eine Ohrendekomposition hat.\\
@@ -2939,7 +2939,7 @@ Graph $G_B = (V_B, E_B)$ mit
         \underline{$IA$} $|E| = 0$: Ein A-B-Pfad ist ein Pfad der Form $(v)$ mit $v \in A \cap B$.
         Außerdem ist die eindeutig minimale Menge, die A von B trennt, $A \cap B$.\\
         Somit gibt es $|A \cap B|$ disjunkte A-B-Pfade und $A_0$ ist bewiesen.
-        
+
         \underline{$IS$} Sei $n \in \N$, sodass $A_n$ gilt.\\ Sei $G = (V,E)$ mit $|E| = n+1$. Sei $A,B \subseteq V$.\\
         Wir müssen $k_{G,A-B}$ disjunkte A-B-Pfade finden.\\
         Sei $e \in E$, betrachte $G' = (V, E \backslash \{e\})$. Sei $e = \{v_1, v_2\}$.
@@ -3057,9 +3057,9 @@ Graph $G_B = (V_B, E_B)$ mit
         (Widerspruchsannahme) Sei $\{u,v\} \in E$ eine Kante, die nicht durchlaufen wird, dann ist (O.B.d.A $u = u_0$) $(v,u_0,\dots,u_l)$ ein längerer Kantenzug in G.
 
         \item \underline{Richtung "$\implies$":} Der Kantenzug startet bei einem Knoten mit ungeradem Grad und endet bei dem anderen Knoten mit ungeradem Grad.\\
-        \underline{Richtung "$\impliedby$":} Seien $u,v \in U$ mit ungeradem Grad. Sei $G':=(V \cup \{w\}, E \cup \{\{u,w\}, \{v,w\}\})$\\
+        \underline{Richtung "$\impliedby$":} Seien $u,v \in V$ mit ungeradem Grad und $w \in U$. Sei $G':=(V \cup \{w\}, E \cup \{\{u,w\}, \{v,w\}\})$\\
         In G' hat jeder Knoten einen geraden Grad, es gibt also den geschlossenen Eulerzug $(w,v,\dots,u,w)$ in G'.\\
-        Deshalb ist $(v,\dots,w)$ ein offener Eulerzug in G.
+        Deshalb ist $(v,\dots,u)$ ein offener Eulerzug in G.
     \end{enumerate}
 }
 
@@ -3099,7 +3099,7 @@ Dann gilt: Wenn es eine Paarung von S gibt, dann $|N(S)| \ge |S|$
     Sei $G=(V,E)$ ein endlicher und zwei-färbbarer Graph. Seien $A \subseteq V$ mit Farbe 1 und $B \subseteq V$ mit Farbe 2.\\
     Dann hat G genau dann eine Paarung von A, wenn gilt:
     \[
-        \forall S \subseteq A: |N(S)| \ge |S|   
+        \forall S \subseteq A: |N(S)| \ge |S|
     \]
 }
 
@@ -3214,7 +3214,7 @@ Schreibweisen:
         $A = \bigcup_{a \in A}a/R$ stimmt, da $a \in a/R$.
         \item \underline{reflexiv:} Sei $a \in A$. Da $A = \bigcup M$, gibt es ein $M \in P: a \in M$.\\
         Dann ist $(a,a) \in M \times M$ und somit $(a,a) \in R_P$
-        
+
         \underline{symmetrisch:} Seien $a,b \in A$ mit $(a,b) \in R_P \iff \exists M \in P$ mit $a,b \in M \iff (b,a) \in R_P$
 
         \underline{transitiv:} Seien $a,b,c \in A$ mit $(a,b),(b,c) \in R_P$\\
@@ -3334,7 +3334,7 @@ Die Antwort darauf liefert die Stirlingsche Partitionszahl $S_{n,k} \in \N$
 \begin{center}
     \begin{tikzpicture}
         \node (1) at (0,0) {1};
-    
+
         \node (2) at (-1,1) {2};
         \node (3) at (0,1) {3};
         \node (5) at (1,1) {5};
@@ -3349,7 +3349,7 @@ Die Antwort darauf liefert die Stirlingsche Partitionszahl $S_{n,k} \in \N$
         \node (30) at (1, 4) {30};
 
         \node (60) at (0, 5) {60};
-    
+
         \draw[->] (2) -- (1);
         \draw[->] (3) -- (1);
         \draw[->] (5) -- (1);

--- a/INF-110-DS/DS.tex
+++ b/INF-110-DS/DS.tex
@@ -3377,7 +3377,7 @@ Die Antwort darauf liefert die Stirlingsche Partitionszahl $S_{n,k} \in \N$
 \end{center}
 
 \de{
-    Eine partielle Ordnung heißt \red{total} oder \red{reflexiv}, falls je zwei Elemente vergleichbar sind, d.h. $\forall a,b \in A: a \le b \lor b \le a$
+    Eine partielle Ordnung heißt \red{total} oder \red{linear}, falls je zwei Elemente vergleichbar sind, d.h. $\forall a,b \in A: a \le b \lor b \le a$
 }
 
 \ex \begin{itemize}


### PR DESCRIPTION
- **Korrektur des offenen Eulerzug Beweises, aber nochmal anschauen wäre gut**
- **Tippfehler: eine totale Ordnung ist nicht das gleiche wie eine reflexive Ordnung**
-  **Falsches Beispiel für unendliche Antiketten gefixt**
